### PR TITLE
Check if command is an executable

### DIFF
--- a/q.sh
+++ b/q.sh
@@ -64,6 +64,10 @@ preexec_invoke_exec () {
         REG=${BASH_REMATCH:1}
         ARGS=${BUFFER:${#BASH_REMATCH}}
 
+	if ! /usr/bin/which $Q_COMMAND; then
+		return 0
+	fi
+
         # If called without register, show help
         if [[ $REG == "" ]]; then
             echo "q - registers for zsh"


### PR DESCRIPTION
Hi. Like your q. But when executing eg. qemu command it is not possible. So for now i just say if something is found in the PATH (which) ignore it. There are more cases to cover but for me it just works for now :)