### PR TITLE
Fixing bug which breaks Cobra Autocomplete

### DIFF
--- a/q.sh
+++ b/q.sh
@@ -133,3 +133,4 @@ EOF
     return 1 # This prevent executing of original command
 }
 trap 'preexec_invoke_exec' DEBUG
+set +T


### PR DESCRIPTION
[Cobra](https://github.com/spf13/cobra) relies on internal error codes (returns 1 when a tab completion doesn't match anything) and not cleaning up after setting the debug mode causes all sorts of problems, including crashing the shell.

Spent several hours bisecting my .bashrc until I found out what was the culprit.